### PR TITLE
Stop connecting after a Bluetooth timeout

### DIFF
--- a/app/src/main/java/com/ginkage/wearmouse/bluetooth/HidDataSender.java
+++ b/app/src/main/java/com/ginkage/wearmouse/bluetooth/HidDataSender.java
@@ -238,6 +238,12 @@ public class HidDataSender
                             // must be an incoming one. In that case, we shouldn't try to disconnect
                             // from it.
                             waitingForDevice = device;
+                        } else if (state == BluetoothProfile.STATE_DISCONNECTED) {
+                            // If we are disconnected from a device we are waiting to connect to, we
+                            // ran into a timeout and should no longer try to connect.
+                            if (device == waitingForDevice) {
+                                waitingForDevice = null;
+                            }
                         }
                         updateDeviceList();
                         for (ProfileListener listener : listeners) {


### PR DESCRIPTION
Currently, wearmouse will never stop trying to connect to a device even after running into a timeout, e.g. if the device is out of range or powered off. With this change, it will return to an idle state after a timeout.